### PR TITLE
Fix ripgrep download failures during Render builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log*
 coverage
 web/dist
 dist
+vendor/vscode-ripgrep/bin/
+vendor/vscode-ripgrep/node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@openai/codex": "^0.39.0",
+        "@vscode/ripgrep": "file:vendor/vscode-ripgrep",
         "ansi-to-html": "^0.7.0",
         "compression": "^1.7.4",
         "express": "^5.1.0",
@@ -3380,38 +3381,8 @@
       }
     },
     "node_modules/@vscode/ripgrep": {
-      "version": "1.15.14",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.14.tgz",
-      "integrity": "sha512-/G1UJPYlm+trBWQ6cMO3sv6b8D1+G16WaJH1/DSqw32JOVlzgZbLkDxRyzIpTpv30AcYGMkCf5tUqGlW6HbDWw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "https-proxy-agent": "^7.0.2",
-        "proxy-from-env": "^1.1.0",
-        "yauzl": "^2.9.2"
-      }
-    },
-    "node_modules/@vscode/ripgrep/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@vscode/ripgrep/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
+      "resolved": "vendor/vscode-ripgrep",
+      "link": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -3430,6 +3401,15 @@
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
       },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3472,16 +3452,12 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-escapes": {
@@ -4100,15 +4076,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/compression/node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -5191,18 +5158,30 @@
         "node": ">= 6"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -6469,6 +6448,33 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6788,9 +6794,9 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8640,6 +8646,37 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "vendor/vscode-ripgrep": {
+      "name": "@vscode/ripgrep",
+      "version": "1.15.14",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.2",
+        "proxy-from-env": "^1.1.0",
+        "yauzl": "^2.9.2"
+      },
+      "devDependencies": {
+        "@types/node": "^20.8.4"
+      }
+    },
+    "vendor/vscode-ripgrep/node_modules/@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "vendor/vscode-ripgrep/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@openai/codex": "^0.39.0",
+    "@vscode/ripgrep": "file:vendor/vscode-ripgrep",
     "ansi-to-html": "^0.7.0",
     "compression": "^1.7.4",
     "express": "^5.1.0",
@@ -36,5 +37,8 @@
     "jest-environment-jsdom": "^29.7.0",
     "supertest": "^7.1.4",
     "vite": "^5.4.8"
+  },
+  "overrides": {
+    "@vscode/ripgrep": "file:vendor/vscode-ripgrep"
   }
 }

--- a/vendor/vscode-ripgrep/LICENSE
+++ b/vendor/vscode-ripgrep/LICENSE
@@ -1,0 +1,13 @@
+vscode-ripgrep
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/vscode-ripgrep/README.md
+++ b/vendor/vscode-ripgrep/README.md
@@ -1,0 +1,25 @@
+# vscode-ripgrep
+
+This is an npm module for using [ripgrep](https://github.com/BurntSushi/ripgrep) in a Node project. It's used by VS Code.
+
+## How it works
+
+- Ripgrep is built in [microsoft/ripgrep-prebuilt](https://github.com/microsoft/ripgrep-prebuilt) and published to releases for each tag in that repo.
+- In this module's postinstall task, it determines which platform it is being installed on and downloads the correct binary from ripgrep-prebuilt for the platform.
+- The path to the ripgrep binary is exported as `rgPath`.
+
+### Usage example
+
+```js
+const { rgPath } = require('vscode-ripgrep');
+
+// child_process.spawn(rgPath, ...)
+```
+
+### Dev note
+
+Runtime dependencies are not allowed in this project. This code runs on postinstall, and any dependencies would only be needed for postinstall, but they would have to be declared as `dependencies`, not `devDependencies`. Then if they were not cleaned up manually, they would end up being included in any project that uses this. I allow `https-proxy-agent` as an exception because we already ship that in VS Code, and `proxy-from-env` because it's very small and much easier to use it than reimplement it.
+
+### GitHub API Limit note
+
+You can produce an API key, set the GITHUB_TOKEN environment var to it, and vscode-ripgrep will use it when downloading from GitHub. This increases your API limit.

--- a/vendor/vscode-ripgrep/SECURITY.md
+++ b/vendor/vscode-ripgrep/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.5 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/vendor/vscode-ripgrep/lib/download.js
+++ b/vendor/vscode-ripgrep/lib/download.js
@@ -1,0 +1,383 @@
+// @ts-check
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const https = require('https');
+const util = require('util');
+const url = require('url');
+const stream = require('stream');
+const child_process = require('child_process');
+const proxy_from_env = require('proxy-from-env');
+const yauzl = require('yauzl'); // use yauzl ^2.9.2 because vscode already ships with it.
+const packageVersion = require('../package.json').version;
+const tmpDir = path.join(os.tmpdir(), `vscode-ripgrep-cache-${packageVersion}`);
+
+const fsUnlink = util.promisify(fs.unlink);
+const fsExists = util.promisify(fs.exists);
+const fsMkdir = util.promisify(fs.mkdir);
+
+const isWindows = os.platform() === 'win32';
+
+const REPO = 'microsoft/ripgrep-prebuilt';
+const pipelineAsync = util.promisify(stream.pipeline);
+
+/**
+ * @param {string} _url
+ */
+function isGithubUrl(_url) {
+    return url.parse(_url).hostname === 'api.github.com';
+}
+
+
+/**
+ * @param {string} _url
+ * @param {fs.PathLike} dest
+ * @param {any} opts
+ */
+function download(_url, dest, opts) {
+
+    const proxy = proxy_from_env.getProxyForUrl(url.parse(_url));
+    if (proxy !== '') {
+        var HttpsProxyAgent = require('https-proxy-agent');
+        opts = {
+            ...opts,
+            "agent": new HttpsProxyAgent.HttpsProxyAgent(proxy),
+            proxy
+        };
+    }
+
+
+    if (opts.headers && opts.headers.authorization && !isGithubUrl(_url)) {
+        delete opts.headers.authorization;
+    }
+
+    return new Promise((resolve, reject) => {
+        console.log(`Download options: ${JSON.stringify(opts)}`);
+        const outFile = fs.createWriteStream(dest);
+        const mergedOpts = {
+            ...url.parse(_url),
+            ...opts
+        };
+        https.get(mergedOpts, response => {
+            console.log('statusCode: ' + response.statusCode);
+            if (response.statusCode === 302) {
+                response.resume();
+                console.log('Following redirect to: ' + response.headers.location);
+                return download(response.headers.location, dest, opts)
+                    .then(resolve, reject);
+            } else if (response.statusCode !== 200) {
+                reject(new Error('Download failed with ' + response.statusCode));
+                return;
+            }
+
+            response.pipe(outFile);
+            outFile.on('finish', () => {
+                resolve();
+            });
+        }).on('error', async err => {
+            await fsUnlink(dest);
+            reject(err);
+        });
+    });
+}
+
+/**
+ * @param {string} _url
+ * @param {any} opts
+ */
+function get(_url, opts) {
+    console.log(`GET ${_url}`);
+
+    const proxy = proxy_from_env.getProxyForUrl(url.parse(_url));
+    if (proxy !== '') {
+        var HttpsProxyAgent = require('https-proxy-agent');
+        opts = {
+            ...opts,
+            "agent": new HttpsProxyAgent.HttpsProxyAgent(proxy)
+        };
+    }
+
+    return new Promise((resolve, reject) => {
+        let result = '';
+        opts = {
+            ...url.parse(_url),
+            ...opts
+        };
+        https.get(opts, response => {
+            if (response.statusCode !== 200) {
+                reject(new Error('Request failed: ' + response.statusCode));
+            }
+
+            response.on('data', d => {
+                result += d.toString();
+            });
+
+            response.on('end', () => {
+                resolve(result);
+            });
+
+            response.on('error', e => {
+                reject(e);
+            });
+        }).on('error', e => reject(e));
+    });
+}
+
+/**
+ * @param {string} repo
+ * @param {string} tag
+ */
+function getApiUrl(repo, tag) {
+    return `https://api.github.com/repos/${repo}/releases/tags/${tag}`;
+}
+
+/**
+ * @param {{ force: boolean; token: string; version: string; }} opts
+ * @param {string} assetName
+ * @param {string} downloadFolder
+ */
+async function getAssetFromGithubApi(opts, assetName, downloadFolder) {
+    const assetDownloadPath = path.join(downloadFolder, assetName);
+
+    // We can just use the cached binary
+    if (!opts.force && await fsExists(assetDownloadPath)) {
+        console.log('Using cached download: ' + assetDownloadPath);
+        return assetDownloadPath;
+    }
+
+    const downloadOpts = {
+        headers: {
+            'user-agent': 'vscode-ripgrep'
+        }
+    };
+
+    if (opts.token) {
+        downloadOpts.headers.authorization = `token ${opts.token}`;
+    }
+
+    const apiUrl = getApiUrl(REPO, opts.version);
+    console.log(`Finding release for ${opts.version}`);
+
+    /**
+     * Attempt to download the asset directly from the GitHub release page
+     * when the API call fails (for example due to rate limiting that returns
+     * a 403). The direct download endpoint does not require an API request
+     * and therefore succeeds in restricted environments such as Render.
+     */
+    async function downloadDirectly() {
+        const directUrl = `https://github.com/${REPO}/releases/download/${opts.version}/${assetName}`;
+        console.log(`Falling back to direct download: ${directUrl}`);
+        await download(directUrl, assetDownloadPath, downloadOpts);
+    }
+
+    let release;
+    try {
+        release = await get(apiUrl, downloadOpts);
+    } catch (error) {
+        if (error && /Request failed: 403/.test(String(error.message || error))) {
+            await downloadDirectly();
+            return;
+        }
+        throw error;
+    }
+
+    let jsonRelease;
+    try {
+        jsonRelease = JSON.parse(release);
+    } catch (e) {
+        throw new Error('Malformed API response: ' + e.stack);
+    }
+
+    if (!jsonRelease.assets) {
+        throw new Error('Bad API response: ' + JSON.stringify(release));
+    }
+
+    const asset = jsonRelease.assets.find(a => a.name === assetName);
+    if (!asset) {
+        console.log('Asset not found in API response, attempting direct download');
+        await downloadDirectly();
+        return;
+    }
+
+    console.log(`Downloading from ${asset.url}`);
+    console.log(`Downloading to ${assetDownloadPath}`);
+
+    downloadOpts.headers.accept = 'application/octet-stream';
+    await download(asset.url, assetDownloadPath, downloadOpts);
+}
+
+/**
+ * @param {string} zipPath
+ * @param {string} destinationDir
+ */
+function unzipWindows(zipPath, destinationDir) {
+    // code from https://stackoverflow.com/questions/63932027/how-to-unzip-to-a-folder-using-yauzl
+    return new Promise((resolve, reject) => {
+        try {
+            // Create folder if not exists
+            fs.promises.mkdir(path.dirname(destinationDir), { recursive: true });
+
+            // Same as example we open the zip.
+            yauzl.open(zipPath, { lazyEntries: true }, (err, zipFile) => {
+                if (err) {
+                    zipFile?.close();
+                    reject(err);
+                    return;
+                }
+
+                // This is the key. We start by reading the first entry.
+                zipFile.readEntry();
+
+                // Now for every entry, we will write a file or dir
+                // to disk. Then call zipFile.readEntry() again to
+                // trigger the next cycle.
+                zipFile.on('entry', (entry) => {
+                    try {
+                        // Directories
+                        if (/\/$/.test(entry.fileName)) {
+                            // Create the directory then read the next entry.
+                            fs.promises.mkdir(path.join(destinationDir, entry.fileName), { recursive: true });
+                            zipFile.readEntry();
+                        }
+                        // Files
+                        else {
+                            // Write the file to disk.
+                            zipFile.openReadStream(entry, (readErr, readStream) => {
+                                if (readErr) {
+                                    zipFile.close();
+                                    reject(readErr);
+                                    return;
+                                }
+
+                                const file = fs.createWriteStream(path.join(destinationDir, entry.fileName));
+                                readStream.pipe(file);
+                                file.on('finish', () => {
+                                    // Wait until the file is finished writing, then read the next entry.
+                                    // @ts-ignore: Typing for close() is wrong.
+                                    file.close(() => {
+                                        zipFile.readEntry();
+                                    });
+
+                                    file.on('error', (err) => {
+                                        zipFile.close();
+                                        reject(err);
+                                    });
+                                });
+                            });
+                        }
+                    } catch (e) {
+                        zipFile.close();
+                        reject(e);
+                    }
+                });
+                zipFile.on('end', (err) => {
+                    resolve();
+                });
+                zipFile.on('error', (err) => {
+                    zipFile.close();
+                    reject(err);
+                });
+            });
+        }
+        catch (e) {
+            reject(e);
+        }
+    });
+}
+
+/**
+ * Handle whitespace in filepath as powershell splits path with whitespaces
+ * @param {string} path
+ */
+function sanitizePathForPowershell(path) {
+    path = path.replace(/ /g, '` '); // replace whitespace with "` " as solution provided here https://stackoverflow.com/a/18537344/7374562
+    return path;
+}
+
+function untar(zipPath, destinationDir) {
+    return new Promise((resolve, reject) => {
+        const unzipProc = child_process.spawn('tar', ['xvf', zipPath, '-C', destinationDir], { stdio: 'inherit' });
+        unzipProc.on('error', err => {
+            reject(err);
+        });
+        unzipProc.on('close', code => {
+            console.log(`tar xvf exited with ${code}`);
+            if (code !== 0) {
+                reject(new Error(`tar xvf exited with ${code}`));
+                return;
+            }
+
+            resolve();
+        });
+    });
+}
+
+/**
+ * @param {string} zipPath
+ * @param {string} destinationDir
+ */
+async function unzipRipgrep(zipPath, destinationDir) {
+    if (isWindows) {
+        await unzipWindows(zipPath, destinationDir);
+    } else {
+        await untar(zipPath, destinationDir);
+    }
+
+    const expectedName = path.join(destinationDir, 'rg');
+    if (await fsExists(expectedName)) {
+        return expectedName;
+    }
+
+    if (await fsExists(expectedName + '.exe')) {
+        return expectedName + '.exe';
+    }
+
+    throw new Error(`Expecting rg or rg.exe unzipped into ${destinationDir}, didn't find one.`);
+}
+
+module.exports = async opts => {
+    if (!opts.version) {
+        return Promise.reject(new Error('Missing version'));
+    }
+
+    if (!opts.target) {
+        return Promise.reject(new Error('Missing target'));
+    }
+
+    const extension = isWindows ? '.zip' : '.tar.gz';
+    const assetName = ['ripgrep', opts.version, opts.target].join('-') + extension;
+
+    if (!await fsExists(tmpDir)) {
+        await fsMkdir(tmpDir);
+    }
+
+    const assetDownloadPath = path.join(tmpDir, assetName);
+    try {
+        await getAssetFromGithubApi(opts, assetName, tmpDir)
+    } catch (e) {
+        console.log('Deleting invalid download cache');
+        try {
+            await fsUnlink(assetDownloadPath);
+        } catch (e) { }
+
+        throw e;
+    }
+
+    console.log(`Unzipping to ${opts.destDir}`);
+    try {
+        const destinationPath = await unzipRipgrep(assetDownloadPath, opts.destDir);
+        if (!isWindows) {
+            await util.promisify(fs.chmod)(destinationPath, '755');
+        }
+    } catch (e) {
+        console.log('Deleting invalid download');
+
+        try {
+            await fsUnlink(assetDownloadPath);
+        } catch (e) { }
+
+        throw e;
+    }
+};

--- a/vendor/vscode-ripgrep/lib/index.d.ts
+++ b/vendor/vscode-ripgrep/lib/index.d.ts
@@ -1,0 +1,1 @@
+export declare const rgPath: string;

--- a/vendor/vscode-ripgrep/lib/index.js
+++ b/vendor/vscode-ripgrep/lib/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const path = require('path');
+
+module.exports.rgPath = path.join(__dirname, `../bin/rg${process.platform === 'win32' ? '.exe' : ''}`);

--- a/vendor/vscode-ripgrep/lib/postinstall.js
+++ b/vendor/vscode-ripgrep/lib/postinstall.js
@@ -1,0 +1,121 @@
+// @ts-check
+'use strict';
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+const child_process = require('child_process');
+
+const download = require('./download');
+
+const fsExists = util.promisify(fs.exists);
+const mkdir = util.promisify(fs.mkdir);
+const exec = util.promisify(child_process.exec);
+
+const forceInstall = process.argv.includes('--force');
+if (forceInstall) {
+    console.log('--force, ignoring caches');
+}
+
+const VERSION = 'v13.0.0-13';
+const MULTI_ARCH_LINUX_VERSION = 'v13.0.0-4';// use this for arm-unknown-linux-gnueabihf and powerpc64le-unknown-linux-gnu until we can fix https://github.com/microsoft/ripgrep-prebuilt/issues/24 and https://github.com/microsoft/ripgrep-prebuilt/issues/32 respectively.
+const BIN_PATH = path.join(__dirname, '../bin');
+
+process.on('unhandledRejection', (reason, promise) => {
+    console.log('Unhandled rejection: ', promise, 'reason:', reason);
+});
+
+async function getTarget() {
+    const arch = process.env.npm_config_arch || os.arch();
+
+    switch (os.platform()) {
+        case 'darwin':
+            return arch === 'arm64' ? 'aarch64-apple-darwin' :
+                'x86_64-apple-darwin';
+        case 'win32':
+            return arch === 'x64' ? 'x86_64-pc-windows-msvc' :
+                arch === 'arm64' ? 'aarch64-pc-windows-msvc' :
+                'i686-pc-windows-msvc';
+        case 'linux':
+            return arch === 'x64' ? 'x86_64-unknown-linux-musl' :
+                arch === 'arm' ? 'arm-unknown-linux-gnueabihf' :
+                arch === 'armv7l' ? 'arm-unknown-linux-gnueabihf' :
+                arch === 'arm64' ? 'aarch64-unknown-linux-musl':
+                arch === 'ppc64' ? 'powerpc64le-unknown-linux-gnu' :
+                arch === 'riscv64' ? 'riscv64gc-unknown-linux-gnu' :
+                arch === 's390x' ? 's390x-unknown-linux-gnu' :
+                    'i686-unknown-linux-musl'
+        default: throw new Error('Unknown platform: ' + os.platform());
+    }
+}
+
+/**
+ * Sleep for a specified number of milliseconds
+ * @param {number} ms Time to sleep in milliseconds
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Retry a function with exponential backoff
+ * @param {Function} fn Function to retry
+ * @param {number} maxRetries Maximum number of retries
+ * @returns {Promise<any>}
+ */
+async function retry(fn, maxRetries = 5) {
+    let retries = 0;
+    let lastError;
+
+    while (retries < maxRetries) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastError = err;
+            retries++;
+
+            if (retries >= maxRetries) {
+                break;
+            }
+
+            const delay = Math.pow(2, retries) * 1000;
+            console.error(err);
+            console.log(`Download attempt ${retries} failed, retrying in ${delay/1000} seconds...`);
+            await sleep(delay);
+        }
+    }
+
+    throw lastError;
+}
+
+async function main() {
+    const binExists = await fsExists(BIN_PATH);
+    if (!forceInstall && binExists) {
+        console.log('bin/ folder already exists, exiting');
+        process.exit(0);
+    }
+
+    if (!binExists) {
+        await mkdir(BIN_PATH);
+    }
+
+    const target = await getTarget();
+    const opts = {
+        version: target === "arm-unknown-linux-gnueabihf" || target === "powerpc64le-unknown-linux-gnu" || target === "s390x-unknown-linux-gnu" ? MULTI_ARCH_LINUX_VERSION: VERSION,
+        token: process.env['GITHUB_TOKEN'],
+        target: await getTarget(),
+        destDir: BIN_PATH,
+        force: forceInstall
+    };
+
+    try {
+        await retry(() => download(opts));
+    } catch (err) {
+        console.error(`Downloading ripgrep failed after multiple retries: ${err.stack}`);
+        process.exit(1);
+    }
+}
+
+main();

--- a/vendor/vscode-ripgrep/package.json
+++ b/vendor/vscode-ripgrep/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@vscode/ripgrep",
+  "version": "1.15.14",
+  "description": "A module for using ripgrep in a Node project",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/vscode-ripgrep"
+  },
+  "scripts": {
+    "postinstall": "node ./lib/postinstall.js"
+  },
+  "author": "Rob Lourens",
+  "license": "MIT",
+  "dependencies": {
+    "https-proxy-agent": "^7.0.2",
+    "yauzl": "^2.9.2",
+    "proxy-from-env": "^1.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.4"
+  }
+}


### PR DESCRIPTION
## Summary
- vendor the `@vscode/ripgrep` package so installs no longer depend on the GitHub releases API
- add a direct-download fallback in the ripgrep postinstall logic to avoid 403 rate-limit errors
- wire the application to use the vendored package and ignore generated ripgrep binaries in git

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf61102c1083288c6b8acc8047536a