### PR TITLE
Fix build output location for Render deployment

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -6,7 +6,9 @@ export default defineConfig({
   root: path.resolve(__dirname, './'),
   publicDir: path.resolve(__dirname, './public'),
   build: {
-    outDir: path.resolve(__dirname, '../dist'),
+    // Output the production bundle alongside the frontend source so the
+    // Express server can serve it from `web/dist`.
+    outDir: path.resolve(__dirname, './dist'),
     emptyOutDir: true
   },
   plugins: [react()],


### PR DESCRIPTION
## Summary
- ensure the Vite production build writes files to `web/dist` so Express can serve them
- add a comment describing the relationship between the frontend build output and the server

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf6456b7c48328935cc14a85f85633