### PR TITLE
Fix catch-all route for Express 5

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -87,7 +87,11 @@ function createServer(options = {}) {
   const distPath = path.resolve(__dirname, '../web/dist');
   if (fs.existsSync(distPath)) {
     app.use('/', serveStatic(distPath));
-    app.get('*', (_req, res) => {
+    // Express 5 uses path-to-regexp@7 which no longer accepts "*" style
+    // catch-all paths. Using a regular expression keeps the behaviour of
+    // serving the client application for any non-API route while remaining
+    // compatible with the new router implementation.
+    app.get(/^\/(?!api).*/, (_req, res) => {
       res.sendFile(path.join(distPath, 'index.html'));
     });
   }


### PR DESCRIPTION
## Summary
- replace the deprecated string catch-all route with a regex compatible with Express 5
- continue serving the built frontend for all non-API requests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf685d86a883289920393566271a50