### PR TITLE
Handle Codex CLI approval mode flag changes

### DIFF
--- a/tests/session-manager-env.test.js
+++ b/tests/session-manager-env.test.js
@@ -50,4 +50,23 @@ describe('session manager environment', () => {
     const spawned = ptyMock.__spawned[0];
     expect(spawned.executable).toBe('/request/codex');
   });
+
+  it('maps legacy approval modes to the new CLI flags', () => {
+    const manager = createSessionManager({ transcriptStore });
+
+    manager.createSession({ approvalMode: 'suggest' });
+    let spawned = ptyMock.__spawned[0];
+    expect(spawned.args).toContain('--ask-for-approval');
+    expect(spawned.args).toContain('untrusted');
+
+    manager.createSession({ approvalMode: 'auto-edit' });
+    spawned = ptyMock.__spawned[1];
+    expect(spawned.args).toContain('--ask-for-approval');
+    expect(spawned.args).toContain('on-request');
+
+    manager.createSession({ approvalMode: 'full-auto' });
+    spawned = ptyMock.__spawned[2];
+    expect(spawned.args).toContain('--full-auto');
+    expect(spawned.args).not.toContain('--ask-for-approval');
+  });
 });


### PR DESCRIPTION
## Summary
- map legacy approval modes to the Codex CLI's new `--ask-for-approval` and `--full-auto` flags
- normalize stored approval modes so sessions report the canonical value
- cover the CLI flag translation with unit tests to guard against regressions

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68cf6a0e5fc0832887d5b89ebb1a724f