### PR TITLE
Improve forecast preferences responsiveness

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -140,12 +140,20 @@ body::before {
 }
 
 .preferences {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   background: rgba(15, 23, 42, 0.06);
   border-radius: 999px;
-  padding: 0.35rem 0.75rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.preferences__item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -168,6 +176,7 @@ body::before {
   font: inherit;
   background: white;
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.15);
+  min-width: 0;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -594,6 +603,17 @@ body::before {
     padding: 1.5rem;
   }
 
+  .preferences {
+    border-radius: 18px;
+    padding: 0.75rem;
+    gap: 0.65rem;
+  }
+
+  .preferences__item {
+    flex: 1 1 140px;
+    justify-content: space-between;
+  }
+
   .timeline__item {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.5rem;
@@ -613,5 +633,22 @@ body::before {
   .status-hero__icon {
     width: 80px;
     height: 80px;
+  }
+}
+
+@media (max-width: 480px) {
+  .preferences {
+    gap: 0.5rem;
+  }
+
+  .preferences__item {
+    flex: 1 1 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.25rem;
+  }
+
+  .select {
+    width: 100%;
   }
 }

--- a/index.html
+++ b/index.html
@@ -68,27 +68,33 @@
               <p id="location-label" class="location-label"></p>
             </div>
             <div class="preferences" role="group" aria-label="Display options">
-              <label class="preferences__label" for="unit-precipitation" data-i18n="preferences.precip">
-                Rain
-              </label>
-              <select id="unit-precipitation" class="select">
-                <option value="mm" data-i18n="preferences.mm">mm</option>
-                <option value="in" data-i18n="preferences.in">inches</option>
-              </select>
-              <label class="preferences__label" for="unit-probability" data-i18n="preferences.probability">
-                Chance
-              </label>
-              <select id="unit-probability" class="select">
-                <option value="percent" data-i18n="preferences.percent">%</option>
-                <option value="qualitative" data-i18n="preferences.qualitative">Low/High</option>
-              </select>
-              <label class="preferences__label" for="language-select" data-i18n="preferences.language">
-                Language
-              </label>
-              <select id="language-select" class="select">
-                <option value="en" data-i18n="preferences.english">English</option>
-                <option value="es" data-i18n="preferences.spanish">Español</option>
-              </select>
+              <div class="preferences__item">
+                <label class="preferences__label" for="unit-precipitation" data-i18n="preferences.precip">
+                  Rain
+                </label>
+                <select id="unit-precipitation" class="select">
+                  <option value="mm" data-i18n="preferences.mm">mm</option>
+                  <option value="in" data-i18n="preferences.in">inches</option>
+                </select>
+              </div>
+              <div class="preferences__item">
+                <label class="preferences__label" for="unit-probability" data-i18n="preferences.probability">
+                  Chance
+                </label>
+                <select id="unit-probability" class="select">
+                  <option value="percent" data-i18n="preferences.percent">%</option>
+                  <option value="qualitative" data-i18n="preferences.qualitative">Low/High</option>
+                </select>
+              </div>
+              <div class="preferences__item">
+                <label class="preferences__label" for="language-select" data-i18n="preferences.language">
+                  Language
+                </label>
+                <select id="language-select" class="select">
+                  <option value="en" data-i18n="preferences.english">English</option>
+                  <option value="es" data-i18n="preferences.spanish">Español</option>
+                </select>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- wrap each forecast preference control with a container so labels stay paired with their selects
- update styles to let the preference chips wrap cleanly and expand full-width on small screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d81172bff08328af6c57d4eb4b9abe